### PR TITLE
Add some numbers to the EventResouce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All strings (the ones I looked at) while adding laravel-form-components are now translatable.
 - Added `EventCleanupReservations` job + command
 - Added ability to delete bookings, in case you screwed up import, and want to do that again.
+- Added following to `EventResource`
+  - `url`: URL of the event for easier access
+  - `total_bookings_count`: Total bookings that are in the system for the event.
+  - `available_bookings_count`: Bookings that are still available to be booked.
 
 ### Changed
 - Changed some flash messages.

--- a/app/Http/Livewire/Bookings.php
+++ b/app/Http/Livewire/Bookings.php
@@ -63,11 +63,7 @@ class Bookings extends Component
             abort_unless(auth()->check() && auth()->user()->isAdmin, 404);
         }
 
-        $this->booked = $this->bookings->where('status', BookingStatus::BOOKED)
-            ->filter(function ($booking) {
-                /** @var Booking $booking */
-                return $booking->flights_count;
-            })->count();
+        $this->booked = $this->bookings->where('status', BookingStatus::BOOKED)->count();
 
         $this->total = $this->bookings->count();
 

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Enums\BookingStatus;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -17,6 +18,8 @@ class EventResource extends JsonResource
      */
     public function toArray($request)
     {
+        $total = $this->bookings->count();
+        $booked = $total - $this->bookings->where('status', BookingStatus::BOOKED)->count();
         return [
             'id' => $this->id,
             'event_type' => $this->type->name,
@@ -36,6 +39,9 @@ class EventResource extends JsonResource
             'is_oceanic_event' => (bool) $this->is_oceanic_event,
             'created_at' => (string) $this->created_at,
             'updated_at' => (string) $this->updated_at,
+            'url' => route('bookings.event.index', $this),
+            'total_bookings_count' => $total,
+            'available_bookings_count' => $booked,
             'links' => [
                 'bookings' => url('/api/events/' . $this->slug . '/bookings'),
                 'dep' => url('/api/airports/' . $this->airportDep->icao),


### PR DESCRIPTION
### Added
- Added following to `EventResource`
  - `url`: URL of the event for easier access
  - `total_bookings_count`: Total bookings that are in the system for the event.
  - `available_bookings_count`: Bookings that are still available to be booked.

Closes #377