### PR TITLE
Add event name to emails that didn't have them yet. Closes #382

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added PHP 8.1 support
+- All e-mails now include the event name as part of subject.
 
 ## [v2.2.6](https://github.com/daveroverts/bmac/compare/v2.2.5...v2.2.6) - 2021-12-13
 

--- a/app/Notifications/BookingCancelled.php
+++ b/app/Notifications/BookingCancelled.php
@@ -42,10 +42,12 @@ class BookingCancelled extends Notification implements ShouldQueue
     public function toMail($notifiable)
     {
         $eventName = $this->event->name;
+        $subject = $eventName . ': ' . __('Booking cancelled');
         return (new MailMessage)
+            ->subject($subject)
             ->greeting('Booking cancelled')
             ->line('Dear ' . $notifiable->full_name . ',')
-            ->line('We’ve processed your cancellation for the ' . $eventName . ' event and opened the slot you held for other pilots to book. Thanks for letting us know.')
+            ->line("We've processed your cancellation for the $eventName event and opened the slot you held for other pilots to book. Thanks for letting us know.")
             ->line('We hope to see you again soon.');
     }
 

--- a/app/Notifications/BookingChanged.php
+++ b/app/Notifications/BookingChanged.php
@@ -43,9 +43,12 @@ class BookingChanged extends Notification implements ShouldQueue
     public function toMail($notifiable)
     {
         $booking = $this->booking;
+        $subject = $booking->event->name . ': ' . __('Booking changed');
         $changes = $this->changes;
 
-        return (new MailMessage)->markdown('emails.booking.changed', ['booking' => $booking, 'changes' => $changes]);
+        return (new MailMessage)
+            ->subject($subject)
+            ->markdown('emails.booking.changed', ['booking' => $booking, 'changes' => $changes]);
     }
 
     /**

--- a/app/Notifications/BookingConfirmed.php
+++ b/app/Notifications/BookingConfirmed.php
@@ -42,8 +42,11 @@ class BookingConfirmed extends Notification implements ShouldQueue
     public function toMail($notifiable)
     {
         $booking = $this->booking;
+        $subject = $booking->event->name . ': ' . __('Booking confirmed');
 
-        return (new MailMessage)->markdown('emails.booking.confirmed', ['booking' => $booking]);
+        return (new MailMessage)
+            ->subject($subject)
+            ->markdown('emails.booking.confirmed', ['booking' => $booking]);
     }
 
     /**

--- a/app/Notifications/BookingDeleted.php
+++ b/app/Notifications/BookingDeleted.php
@@ -42,8 +42,10 @@ class BookingDeleted extends Notification implements ShouldQueue
     public function toMail($notifiable)
     {
         $event = $this->event;
+        $subject = $event->name . ': ' . __('Booking deleted');
 
         return (new MailMessage)
+            ->subject($subject)
             ->greeting('Booking deleted')
             ->line('Dear ' . $notifiable->full_name . ',')
             ->line('Your booking for ' . $event->name . ' event has been removed by an administrator.')

--- a/app/Notifications/EventFinalInformation.php
+++ b/app/Notifications/EventFinalInformation.php
@@ -43,9 +43,12 @@ class EventFinalInformation extends Notification implements ShouldQueue
     public function toMail($notifiable)
     {
         $booking = $this->booking;
+        $subject = $booking->event->name . ': ' . __('Booking confirmed');
         $template = $booking->event->event_type_id == EventType::MULTIFLIGHTS ? 'emails.event.finalInformation_multiflights' : 'emails.event.finalInformation';
         $flight = $booking->flights->first() ?? null;
-        return (new MailMessage)->markdown($template, compact('booking', 'flight'));
+        return (new MailMessage)
+            ->subject($subject)
+            ->markdown($template, compact('booking', 'flight'));
     }
 
     /**


### PR DESCRIPTION
### Added
- All e-mails now include the event name as part of subject.