### PR TITLE
Add OAUTH_SCOPES Environment Variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,7 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 OAUTH_BASE=https://auth.vatsim.net
 OAUTH_CLIENT=
 OAUTH_SECRET=
+OAUTH_SCOPES="full_name,email"
 
 # OAuth variable mapping, leave it as is for Vatsim Connect
 # This allows you to fit the data validation your OAuth2 service, the - character indicates array structure

--- a/config/oauth.php
+++ b/config/oauth.php
@@ -32,7 +32,7 @@ return [
     /**
      * The scopes the user will be requested
      */
-    'scopes' => explode(',', "full_name,email"),
+    'scopes' => explode(',', env('OAUTH_SCOPES', 'full_name,email')),
 
     /*
      * OAuth variable mapping


### PR DESCRIPTION
Thanks for the work on this platform, and the comprehensive README to get up and running!

Whilst deploying a version of bmac that integrated with our own oauth provider, we hit a snag where we couldn't override the scopes being requested. As our oauth provider is only used for internal apps that we control, we don't support scopes and return the same (limited) data to all clients.

This PR implements a change that allows the oauth scope to be overridden from the default via a new `OAUTH_SCOPES` env var.

Given it is unlikely to be heavily used, I opted not to include this in the `.env.example` file but accept that adding it may more closely align to the pattern already established.